### PR TITLE
Fix Vite Build TypeError in manualChunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,29 +64,42 @@ export default defineConfig({
     outDir: 'dist',
     rollupOptions: {
       output: {
-        manualChunks: {
-          // Core React libraries
-          'vendor-react': ['react', 'react-dom'],
-          'vendor-router': ['react-router-dom'],
-
-          // Heavy 3D libraries - separate chunk for lazy loading
-          'vendor-three': ['three', '@react-three/fiber', '@react-three/drei', '@react-three/cannon'],
-
-          // Animation libraries
-          'vendor-animation': ['framer-motion', 'gsap'],
-
-          // UI components and icons
-          'vendor-ui': ['lucide-react', 'react-icons'],
-
-          // Carousel and sliders
-          'vendor-carousel': ['swiper'],
-
-          // Utilities and smaller libs
-          'vendor-utils': ['typewriter-effect', 'react-hot-toast', 'gray-matter'],
-
-          // Analytics and tracking
-          'vendor-analytics': ['@microsoft/clarity', '@supabase/supabase-js']
-        }
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            // Check for specific vendors first to avoid overlap (e.g., react-router-dom contains 'react')
+            if (id.includes('react-router-dom')) {
+              return 'vendor-router';
+            }
+            if (id.includes('react-icons') || id.includes('lucide-react')) {
+              return 'vendor-ui';
+            }
+            if (id.includes('three') || id.includes('@react-three')) {
+              return 'vendor-three';
+            }
+            if (id.includes('framer-motion') || id.includes('gsap')) {
+              return 'vendor-animation';
+            }
+            if (id.includes('swiper')) {
+              return 'vendor-carousel';
+            }
+            if (
+              id.includes('typewriter-effect') ||
+              id.includes('react-hot-toast') ||
+              id.includes('gray-matter')
+            ) {
+              return 'vendor-utils';
+            }
+            if (
+              id.includes('@microsoft/clarity') ||
+              id.includes('@supabase/supabase-js')
+            ) {
+              return 'vendor-analytics';
+            }
+            if (id.includes('react') || id.includes('react-dom')) {
+              return 'vendor-react';
+            }
+          }
+        },
       }
     },
     chunkSizeWarningLimit: 1000,


### PR DESCRIPTION
Refactored `manualChunks` in `vite.config.ts` from an object to a function. This change was necessary to resolve a TypeError (`manualChunks is not a function`) encountered during the build process with Vite v8.0.11, which uses Rolldown. The new function-based configuration preserves the original vendor grouping strategy for core React libraries, router, 3D libraries, animation, UI icons, carousel, utilities, and analytics. Verified the fix by successfully running `npm run build`.

---
*PR created automatically by Jules for task [4242916823588086343](https://jules.google.com/task/4242916823588086343) started by @nirzaf*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `vite` v8 build error by converting `manualChunks` in vite.config.ts from an object to a function compatible with Rolldown. Keeps the existing vendor chunking (React, router, 3D, animation, UI, carousel, utils, analytics) and restores successful builds.

<sup>Written for commit 91902e4046be1b661e5942aa41a207cf211870d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

